### PR TITLE
remove unneeded GCC flags (already enabled by -O3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ else ifneq ($(findstring win,$(shell uname -a)),)
 endif
 endif
 
-HAVE_GCC = 0
-
 ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
@@ -100,7 +98,6 @@ else ifeq ($(platform), ctr)
    CFLAGS += -D_3DS
    PLATFORM_DEFINES := -D_3DS
    STATIC_LINKING := 1
-   HAVE_GCC = 1
 else
    TARGET := $(TARGET_NAME)_libretro.dll
    CC = gcc

--- a/Makefile.common
+++ b/Makefile.common
@@ -81,13 +81,6 @@ DEFINES += -finline -fsigned-char
 DEFINES += -fomit-frame-pointer
 DEFINES += -ffast-math -fstrict-aliasing
 
-ifeq ($(HAVE_GCC), 1)
-DEFINES += -mstructure-size-boundary=32
-DEFINES += -finline-functions -fexpensive-optimizations
-DEFINES += -falign-functions=32 -falign-loops -falign-labels
-DEFINES += -falign-jumps -frename-registers -fweb
-endif
-
 else
 SOURCES += $(CORE_DIR)/ppu_.c
 SOURCES += $(CORE_DIR)/gfx.c

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -8,7 +8,6 @@ ifeq ($(TARGET_ARCH),arm)
 ARM_ASM         = 1
 ASM_CPU         = 0
 ASM_SPC700      = 0
-HAVE_GCC        = 1
 LOCAL_CFLAGS   += -DANDROID_ARM
 LOCAL_ARM_MODE := arm
 endif


### PR DESCRIPTION
These GCC parameters are not needed - on gcc on linux on ARM and x86_64 all are already enabled by O3 - (although falign-functions is not set to 32 - should be best left to target default imho)

```
on ARM (Linux on RPI)

gcc -Q --help=target | grep "structure-size"
  -mstructure-size-boundary=  		0x20

on ARM and x86_64 gcc
gcc -Q --help=optimizers -O3 | grep "inline-function\|expensive-optimization\|align-loops\|align-labels\|align-jumps\|rename-registers\|web"
  -falign-jumps               		[enabled]
  -falign-labels              		[enabled]
  -falign-loops               		[enabled]
  -fexpensive-optimizations   		[enabled]
  -finline-functions          		[enabled]
  -finline-functions-called-once 	[enabled]
  -frename-registers          		[enabled]
  -fweb                       		[enabled]

```


