### PR TITLE
remove some more gcc opts -

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,7 @@ ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=libretro/link.T -Wl,--no-undefined
-   CFLAGS += -fno-builtin \
-            -fno-exceptions -ffunction-sections \
-             -fomit-frame-pointer -fgcse-sm -fgcse-las -fgcse-after-reload \
-             -fweb -fpeel-loops
+   CFLAGS += -fno-builtin -fno-exceptions
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC

--- a/Makefile.common
+++ b/Makefile.common
@@ -78,7 +78,6 @@ endif
 DEFINES += -DARM_ASM
 DEFINES += -DRIGHTSHIFT_IS_SAR
 DEFINES += -finline -fsigned-char
-DEFINES += -fomit-frame-pointer
 DEFINES += -ffast-math -fstrict-aliasing
 
 else
@@ -94,8 +93,6 @@ endif
 #DEFINES += -DVAR_CYCLES
 #DEFINES += -D_C_GW_
 #DEFINES +=  -DFAST_LSB_WORD_ACCESS
-
-DEFINES += -ffast-math -funroll-loops -fomit-frame-pointer
 
 INCLUDES   = -I$(LIBRETRO_DIR) -I$(CORE_DIR) -I.
 DEFINES    += -DHAVE_STRINGS_H -DHAVE_STDINT_H -DHAVE_INTTYPES_H -D__LIBRETRO__ -DINLINE=inline


### PR DESCRIPTION
 * -fgcse-sm -fgcse-las - let gcc decide via O3
 * -ffunction-sections / -fpeel-loops / -funroll-loops (normally only used when profiling shows there are actual benefits - unrolling loops may not be of benefit on all targets)
 * -fgcse-after-reload / -fweb (already enabled by -O3)
 * a few duplicate -fomit-frame-pointer / -ffast-math